### PR TITLE
Update HCP Packer resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,32 +29,29 @@ To use in your own environment, update main.tf to change the Terraform Cloud org
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.20 |
-| <a name="requirement_hcp"></a> [hcp](#requirement\_hcp) | ~> 0.35 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.9 |
+| <a name="requirement_hcp"></a> [hcp](#requirement\_hcp) | ~> 0.82 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.60.0 |
-| <a name="provider_hcp"></a> [hcp](#provider\_hcp) | 0.56.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.9 |
+| <a name="provider_hcp"></a> [hcp](#provider\_hcp) | ~> 0.82 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bastion_sg"></a> [bastion\_sg](#module\_bastion\_sg) | terraform-aws-modules/security-group/aws | ~> 4.5 |
-| <a name="module_ecs_alb_sg"></a> [ecs\_alb\_sg](#module\_ecs\_alb\_sg) | terraform-aws-modules/security-group/aws | ~> 4.5 |
-| <a name="module_ecs_nginx_sg"></a> [ecs\_nginx\_sg](#module\_ecs\_nginx\_sg) | terraform-aws-modules/security-group/aws | ~> 4.5 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.18 |
+| <a name="module_bastion_sg"></a> [bastion\_sg](#module\_bastion\_sg) | terraform-aws-modules/security-group/aws | ~> 5.1 |
+| <a name="module_ecs_alb_sg"></a> [ecs\_alb\_sg](#module\_ecs\_alb\_sg) | terraform-aws-modules/security-group/aws | ~> 5.1 |
+| <a name="module_ecs_nginx_sg"></a> [ecs\_nginx\_sg](#module\_ecs\_nginx\_sg) | terraform-aws-modules/security-group/aws | ~> 5.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.1 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_acm_certificate.frontend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
 | [aws_dynamodb_table.products](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_dynamodb_table_item.products](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table_item) | resource |
 | [aws_ecs_cluster.frontend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
@@ -82,43 +79,30 @@ To use in your own environment, update main.tf to change the Terraform Cloud org
 | [aws_launch_template.eks_nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_lb.ecs_frontend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.ecs_frontend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.ecs_frontend_tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_target_group.ecs_frontend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_s3_bucket.assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_logging.assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_ownership_controls.assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
-| [aws_s3_bucket_ownership_controls.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
-| [aws_s3_bucket_versioning.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_object.images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
-| [tls_private_key.frontend](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [tls_self_signed_cert.frontend](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [aws_default_tags.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
-| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.assets_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [hcp_packer_image.base](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/data-sources/packer_image) | data source |
-| [hcp_packer_image.nginx](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/data-sources/packer_image) | data source |
+| [hcp_packer_artifact.base](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/data-sources/packer_artifact) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_bastion_instance_type"></a> [bastion\_instance\_type](#input\_bastion\_instance\_type) | EC2 instance type for the bastion instance. | `string` | `"t3.micro"` | no |
 | <a name="input_bastion_packer_bucket"></a> [bastion\_packer\_bucket](#input\_bastion\_packer\_bucket) | The HCP Packer bucket name for the bastion instance. | `string` | n/a | yes |
-| <a name="input_bastion_packer_channel"></a> [bastion\_packer\_channel](#input\_bastion\_packer\_channel) | The HCP Packer channel name for the bastion instance. | `string` | `"development"` | no |
-| <a name="input_eks_node_instance_type"></a> [eks\_node\_instance\_type](#input\_eks\_node\_instance\_type) | EC2 instance type for the EKS nodes. | `string` | `"t3.medium"` | no |
-| <a name="input_env"></a> [env](#input\_env) | Environment for this deployment. | `string` | `"dev"` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | Name of the person responsible for this deployment. | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix for resource names. Will be combined with `env` to generate unique names. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | n/a | yes |
+| <a name="input_bastion_instance_type"></a> [bastion\_instance\_type](#input\_bastion\_instance\_type) | EC2 instance type for the bastion instance. | `string` | `"t3.micro"` | no |
+| <a name="input_bastion_packer_channel"></a> [bastion\_packer\_channel](#input\_bastion\_packer\_channel) | The HCP Packer channel name for the bastion instance. | `string` | `"development"` | no |
+| <a name="input_eks_node_instance_type"></a> [eks\_node\_instance\_type](#input\_eks\_node\_instance\_type) | EC2 instance type for the EKS nodes. | `string` | `"t3.medium"` | no |
+| <a name="input_env"></a> [env](#input\_env) | Environment for this deployment. | `string` | `"dev"` | no |
 
 ## Outputs
 
@@ -128,5 +112,4 @@ To use in your own environment, update main.tf to change the Terraform Cloud org
 | <a name="output_bastion_hostname"></a> [bastion\_hostname](#output\_bastion\_hostname) | Public hostname of the bastion instance. |
 | <a name="output_eks_endpoint"></a> [eks\_endpoint](#output\_eks\_endpoint) | API endpoint of the EKS cluster. |
 | <a name="output_frontend_url"></a> [frontend\_url](#output\_frontend\_url) | URL of the frontend load balancer. |
-| <a name="output_log_bucket_name"></a> [log\_bucket\_name](#output\_log\_bucket\_name) | Name of the logging bucket. |
 <!-- END_TF_DOCS -->

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,14 +1,14 @@
 ## EC2 resources
 
-data "hcp_packer_image" "base" {
-  bucket_name    = var.bastion_packer_bucket
-  channel        = var.bastion_packer_channel
-  cloud_provider = "aws"
-  region         = var.region
+data "hcp_packer_artifact" "base" {
+  bucket_name  = var.bastion_packer_bucket
+  channel_name = var.bastion_packer_channel
+  platform     = "aws"
+  region       = var.region
 }
 
 resource "aws_instance" "bastion" {
-  ami                         = data.hcp_packer_image.base.cloud_image_id
+  ami                         = data.hcp_packer_artifact.base.external_identifier
   instance_type               = var.bastion_instance_type
   associate_public_ip_address = true
   subnet_id                   = module.vpc.public_subnets[0]

--- a/eks.tf
+++ b/eks.tf
@@ -10,7 +10,7 @@ resource "aws_eks_cluster" "backend" {
     subnet_ids              = concat(module.vpc.public_subnets, module.vpc.private_subnets)
     endpoint_public_access  = true
     endpoint_private_access = true
-    public_access_cidrs = [ "0.0.0.0/0" ]
+    public_access_cidrs     = ["0.0.0.0/0"]
   }
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ terraform {
     }
     hcp = {
       source  = "hashicorp/hcp"
-      version = ">= 0.60.0, < 0.84.0"
+      version = "~> 0.82"
     }
   }
 
@@ -42,7 +42,7 @@ provider "hcp" {}
 data "aws_default_tags" "default" {}
 
 locals {
-  name  = "${var.prefix}-hashicafe-${var.env}"
+  name = "${var.prefix}-hashicafe-${var.env}"
 }
 
 module "vpc" {


### PR DESCRIPTION
Replace the deprecated `hcp_packer_image` resource with `hcp_packer_artifact` and update the HCP provider constraint.